### PR TITLE
Updated normalize and bootstrap

### DIFF
--- a/views/head.jade
+++ b/views/head.jade
@@ -6,16 +6,16 @@ meta(name="viewport", content="width=device-width, initial-scale=1.0, maximum-sc
 link(rel='icon', type='image/png', href='/images/icon.png')
 
 // Stylesheets too include
-link(rel='stylesheet', href="https://fonts.googleapis.com/css?family=Open+Sans|Russo+One|Ubuntu+Mono")
-link(rel='stylesheet', href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css")
-link(rel='stylesheet', href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.min.css")
+link(rel='stylesheet', href="//fonts.googleapis.com/css?family=Open+Sans|Russo+One|Ubuntu+Mono")
+link(rel='stylesheet', href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize#{min}.css")
+link(rel='stylesheet', href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap#{min}.css")
 link(rel='stylesheet', href="/lib/pagr/stylesheets/pagr.css")
 link(rel='stylesheet', href="/stylesheets/style.css")
 
 // Scripts to include
 script(src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery#{min}.js")
 script(src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.3/jquery-ui#{min}.js")
-script(src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/js/bootstrap.min.js")
+script(src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/js/bootstrap#{min}.js")
 script(src="/lib/pdf.js/pdf.js")
 script(src="/lib/pdf.js/compatibility.js")
 script(src="")

--- a/views/head.jade
+++ b/views/head.jade
@@ -7,15 +7,15 @@ link(rel='icon', type='image/png', href='/images/icon.png')
 
 // Stylesheets too include
 link(rel='stylesheet', href="https://fonts.googleapis.com/css?family=Open+Sans|Russo+One|Ubuntu+Mono")
-link(rel='stylesheet', href="//cdnjs.cloudflare.com/ajax/libs/normalize/2.1.3/normalize.min.css")
-link(rel='stylesheet', href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0-rc2/css/bootstrap#{min}.css")
+link(rel='stylesheet', href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css")
+link(rel='stylesheet', href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/css/bootstrap.min.css")
 link(rel='stylesheet', href="/lib/pagr/stylesheets/pagr.css")
 link(rel='stylesheet', href="/stylesheets/style.css")
 
 // Scripts to include
 script(src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery#{min}.js")
 script(src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.3/jquery-ui#{min}.js")
-script(src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0-rc2/js/bootstrap#{min}.js")
+script(src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.3/js/bootstrap.min.js")
 script(src="/lib/pdf.js/pdf.js")
 script(src="/lib/pdf.js/compatibility.js")
 script(src="")


### PR DESCRIPTION
The previous link to normalize.css was outdated/broken and I updated the bootstrap version to the highest patch version before 3.1.0. Have not tested.
